### PR TITLE
fix(sync): correctly upload unhashed files

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -140,7 +140,7 @@ export class SnowballSync extends Command {
       }
     } else {
       // Only upload files that have no hash
-      files = files.filter((f) => f.hash === null);
+      files = files.filter((f) => f.hash == null);
     }
 
     log.info({ startOffset: 0, files: files.length }, 'Upload:Start');


### PR DESCRIPTION
file hash will never `=== null` as it is either a string or undefined.
